### PR TITLE
Fix trailing slash

### DIFF
--- a/src/features/router/useSmoothRouter.tsx
+++ b/src/features/router/useSmoothRouter.tsx
@@ -43,7 +43,11 @@ const useSmoothRouter = () => {
 
                     const response = await fetch(href)
                     if (response.redirected) {
-                        history.pushState({ ...currentPageState }, "", href)
+                        history.pushState(
+                            { ...currentPageState },
+                            "",
+                            response.url
+                        )
                         navigateToPage(response.url)
                         return
                     }

--- a/src/features/router/useSmoothRouter.tsx
+++ b/src/features/router/useSmoothRouter.tsx
@@ -15,7 +15,7 @@ const useSmoothRouter = () => {
     }
 
     const navigateToPage = useCallback(
-        async (href: string, newState?: PageData) => {
+        async (href: string, newState?: PageData, isFromRedirect?: boolean) => {
             try {
                 const currentPageState =
                     (history.state as PageData) || undefined
@@ -39,16 +39,20 @@ const useSmoothRouter = () => {
                 if (newState) {
                     pageData = newState
                 } else {
-                    history.pushState(null, "", href)
+                    if (isFromRedirect) {
+                        history.replaceState(null, "", href)
+                    } else {
+                        history.pushState(null, "", href)
+                    }
 
                     const response = await fetch(href)
                     if (response.redirected) {
-                        history.pushState(
+                        history.replaceState(
                             { ...currentPageState },
                             "",
                             response.url
                         )
-                        navigateToPage(response.url)
+                        navigateToPage(response.url, undefined, true)
                         return
                     }
                     const htmlText = await response.text()

--- a/src/features/router/useSmoothRouter.tsx
+++ b/src/features/router/useSmoothRouter.tsx
@@ -42,6 +42,11 @@ const useSmoothRouter = () => {
                     history.pushState(null, "", href)
 
                     const response = await fetch(href)
+                    if (response.redirected) {
+                        history.pushState({ ...currentPageState }, "", href)
+                        navigateToPage(response.url)
+                        return
+                    }
                     const htmlText = await response.text()
                     const document = await parseDocumentFromText(htmlText)
 


### PR DESCRIPTION
navigating to folder with url like `studres.../folder`(no slash at the end) will redirect to correct page, but was not accounted in better studres navigation

this pr fixes it finally fixes it, hopefully for good